### PR TITLE
Retire GUC parallel_hash_enable_motion_broadcast

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2871,8 +2871,7 @@ cdbpath_motion_for_parallel_join(PlannerInfo *root,
 						List *inner_pathkeys,
 						bool outer_require_existing_order,
 						bool inner_require_existing_order,
-						bool parallel_aware,
-						bool uninterested_broadcast)
+						bool parallel_aware)
 {
 	CdbpathMfjRel outer;
 	CdbpathMfjRel inner;
@@ -3699,7 +3698,7 @@ cdbpath_motion_for_parallel_join(PlannerInfo *root,
 		else if (!small_rel->require_existing_order &&
 				 small_rel->ok_to_replicate &&
 				 ((!parallel_aware && (small_rel->bytes * CdbPathLocus_NumSegmentsPlusParallelWorkers(large_rel->locus) < large_rel->bytes)) ||
-				  (parallel_aware && !uninterested_broadcast && (small_rel->bytes * CdbPathLocus_NumSegments(large_rel->locus) < large_rel->bytes))))
+				  (parallel_aware && (small_rel->bytes * CdbPathLocus_NumSegments(large_rel->locus) < large_rel->bytes))))
 				{
 					if (!parallel_aware)
 						CdbPathLocus_MakeReplicated(&small_rel->move_to,
@@ -3718,7 +3717,7 @@ cdbpath_motion_for_parallel_join(PlannerInfo *root,
 		else if (!large_rel->require_existing_order &&
 				 large_rel->ok_to_replicate &&
 				 ((!parallel_aware && (large_rel->bytes * CdbPathLocus_NumSegmentsPlusParallelWorkers(small_rel->locus) < small_rel->bytes)) ||
-				  (parallel_aware && !uninterested_broadcast && (large_rel->bytes * CdbPathLocus_NumSegments(small_rel->locus) < small_rel->bytes))))
+				  (parallel_aware && (large_rel->bytes * CdbPathLocus_NumSegments(small_rel->locus) < small_rel->bytes))))
 				{
 					if (!parallel_aware)
 						CdbPathLocus_MakeReplicated(&large_rel->move_to,
@@ -3749,7 +3748,7 @@ cdbpath_motion_for_parallel_join(PlannerInfo *root,
 		else if (!small_rel->require_existing_order &&
 				 small_rel->ok_to_replicate &&
 				 ((!parallel_aware && (small_rel->bytes * CdbPathLocus_NumSegmentsPlusParallelWorkers(large_rel->locus) < small_rel->bytes + large_rel->bytes)) ||
-					(parallel_aware && !uninterested_broadcast && (small_rel->bytes * CdbPathLocus_NumSegments(large_rel->locus) < small_rel->bytes + large_rel->bytes))))
+					(parallel_aware && (small_rel->bytes * CdbPathLocus_NumSegments(large_rel->locus) < small_rel->bytes + large_rel->bytes))))
 				{
 					if (!parallel_aware)
 						CdbPathLocus_MakeReplicated(&small_rel->move_to,
@@ -3765,7 +3764,7 @@ cdbpath_motion_for_parallel_join(PlannerInfo *root,
 				else if (!large_rel->require_existing_order &&
 						 large_rel->ok_to_replicate &&
 						 ((!parallel_aware && (large_rel->bytes * CdbPathLocus_NumSegmentsPlusParallelWorkers(small_rel->locus) < small_rel->bytes + large_rel->bytes)) ||
-						  (parallel_aware && !uninterested_broadcast && (large_rel->bytes * CdbPathLocus_NumSegments(small_rel->locus) < small_rel->bytes + large_rel->bytes))))
+						  (parallel_aware && (large_rel->bytes * CdbPathLocus_NumSegments(small_rel->locus) < small_rel->bytes + large_rel->bytes))))
 				{
 					if (!parallel_aware)
 						CdbPathLocus_MakeReplicated(&large_rel->move_to,

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3911,7 +3911,6 @@ create_nestloop_path(PlannerInfo *root,
 											 NIL,
 											 outer_must_be_local,
 											 inner_must_be_local,
-											 false,
 											 false);
 	}
 
@@ -4191,7 +4190,6 @@ create_mergejoin_path(PlannerInfo *root,
 											 innermotionkeys,
 											 preserve_outer_ordering,
 											 preserve_inner_ordering,
-											 false,
 											 false);
 	}
 
@@ -4332,8 +4330,7 @@ create_hashjoin_path(PlannerInfo *root,
 					 List *restrict_clauses,
 					 Relids required_outer,
 					 List *redistribution_clauses, /* CDB */
-					 List *hashclauses,
-					 bool uninterested_broadcast) /* GPDB parallel */
+					 List *hashclauses)
 {
 	HashPath   *pathnode;
 	CdbPathLocus join_locus;
@@ -4378,8 +4375,7 @@ create_hashjoin_path(PlannerInfo *root,
 											 NIL,
 											 outer_must_be_local,
 											 inner_must_be_local,
-											 parallel_hash,
-											 uninterested_broadcast);
+											 parallel_hash);
 	}
 
 	if (CdbPathLocus_IsNull(join_locus))

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -303,7 +303,6 @@ bool		optimizer_enable_indexjoin;
 bool		optimizer_enable_motions_masteronly_queries;
 bool		optimizer_enable_motions;
 bool		optimizer_enable_motion_broadcast;
-bool		parallel_hash_enable_motion_broadcast;
 bool		optimizer_enable_motion_gather;
 bool		optimizer_enable_motion_redistribute;
 bool		optimizer_enable_sort;
@@ -2087,16 +2086,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_motion_broadcast,
-		true,
-		NULL, NULL, NULL
-	},
-	{
-		{"parallel_hash_enable_motion_broadcast", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Enable plans with Motion Broadcast operators in parallel hash join."),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&parallel_hash_enable_motion_broadcast,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -74,7 +74,6 @@ cdbpath_motion_for_parallel_join(PlannerInfo    *root,
 						List           *inner_pathkeys,
 						bool            outer_require_existing_order,
 						bool            inner_require_existing_order,
-						bool			parallel_aware,
-						bool			uninterested_broadcast); /* for parallel hash join, do not use Broadcast if possible */
+						bool			parallel_aware);
 
 #endif   /* CDBPATH_H */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -216,8 +216,7 @@ extern Path *create_hashjoin_path(PlannerInfo *root,
 									  List *restrict_clauses,
 									  Relids required_outer,
 									  List *redistribution_clauses,    /*CDB*/
-									  List *hashclauses,
-									  bool uninterested_broadcast); /* GPDB parallel */
+									  List *hashclauses);
 
 extern ProjectionPath *create_projection_path(PlannerInfo *root,
 											  RelOptInfo *rel,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -496,7 +496,6 @@ extern bool optimizer_enable_indexjoin;
 extern bool optimizer_enable_motions_masteronly_queries;
 extern bool optimizer_enable_motions;
 extern bool optimizer_enable_motion_broadcast;
-extern bool parallel_hash_enable_motion_broadcast;
 extern bool optimizer_enable_motion_gather;
 extern bool optimizer_enable_motion_redistribute;
 extern bool optimizer_enable_sort;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -424,7 +424,6 @@
 		"optimizer_enable_materialize",
 		"optimizer_enable_mergejoin",
 		"optimizer_enable_motion_broadcast",
-		"parallel_hash_enable_motion_broadcast",
 		"optimizer_enable_motion_gather",
 		"optimizer_enable_motion_redistribute",
 		"optimizer_enable_motions",


### PR DESCRIPTION
It's added by history reasons as a workaround.
We don't have exactly the right parallel feature at the time. It's neither reasonable to keep it, nor we have test cases for this wired GUC.
Retire it and keep codes same with UPSTREAM.

Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to @cloudberrydb/dev team for review and approval when your PR is ready🥳
