### PR TITLE
[AQUMV] Support  GROUP BY, GROUPING SETS, ROLLUP, CUBE in origin query.

### DIFF
--- a/src/backend/optimizer/README.cbdb.aqumv
+++ b/src/backend/optimizer/README.cbdb.aqumv
@@ -225,7 +225,7 @@ Below are not supported now:
       Order by(for origin_query)
       Join
       Sublink
-      Group by
+      Group By/Grouping Sets/Rollup/Cube (on mv_query)
       Window Functions
       CTE
       Distinct On

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1878,7 +1878,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH &&
 			enable_answer_query_using_materialized_views)
-			current_rel = answer_query_using_materialized_views(root, current_rel);
+			current_rel = answer_query_using_materialized_views(root, current_rel, standard_qp_callback, &qp_extra);
 
 		/*
 		 * Convert the query's result tlist into PathTarget format.

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -165,4 +165,9 @@ extern void cdb_extract_plan_dependencies(PlannerInfo *root, Plan *plan);
 
 extern void add_proc_oids_for_dump(Oid funcid);
 
+extern RelOptInfo* answer_query_using_materialized_views(PlannerInfo *root,
+														RelOptInfo *current_rel,
+														query_pathkeys_callback qp_callback,
+														void *qp_extra);
+
 #endif							/* PLANMAIN_H */

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -62,8 +62,6 @@ extern Expr *preprocess_phv_expression(PlannerInfo *root, Expr *expr);
 
 extern bool optimizer_init;
 
-extern RelOptInfo* answer_query_using_materialized_views(PlannerInfo *root, RelOptInfo *current_rel);
-
 extern void preprocess_qual_conditions(PlannerInfo *root, Node *jtnode);
 
 #endif							/* PLANNER_H */

--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -986,6 +986,396 @@ select count(c2), count(*) from aqumv_t2 where c1 > 90;
 (1 row)
 
 abort;
+--
+-- Test Group By clause of origin query.
+-- GROUPING SETS
+-- ROLLUP
+-- CUBE
+--
+begin;
+create table aqumv_t3(c1 int, c2 int, c3 int) distributed by (c1);
+insert into aqumv_t3 select i, i+1, i+2 from generate_series(1, 100) i;
+insert into aqumv_t3 values (91, NULL, 95);
+analyze aqumv_t3;
+create incremental materialized view aqumv_mvt3_0 as
+  select c1 as mc1, c2 as mc2, c3 as mc3
+  from aqumv_t3 where c1 > 90;
+analyze aqumv_mvt3_0;
+-- Group By
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by c1, c3;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: c1, c3, (count(c2))
+   ->  HashAggregate
+         Output: c1, c3, count(c2)
+         Group Key: aqumv_t3.c1, aqumv_t3.c3
+         ->  Seq Scan on public.aqumv_t3
+               Output: c1, c2, c3
+               Filter: (aqumv_t3.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by c1, c3;
+ c1  | c3  | count 
+-----+-----+-------
+  94 |  96 |     1
+  93 |  95 |     1
+  99 | 101 |     1
+  97 |  99 |     1
+  92 |  94 |     1
+  98 | 100 |     1
+  95 |  97 |     1
+  91 |  93 |     1
+  91 |  95 |     0
+ 100 | 102 |     1
+  96 |  98 |     1
+(11 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by c1, c3;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: mc1, mc3, (count(mc2))
+   ->  HashAggregate
+         Output: mc1, mc3, count(mc2)
+         Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
+         ->  Seq Scan on public.aqumv_mvt3_0
+               Output: mc1, mc2, mc3
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by c1, c3;
+ c1  | c3  | count 
+-----+-----+-------
+  94 |  96 |     1
+  93 |  95 |     1
+  99 | 101 |     1
+  97 |  99 |     1
+  92 |  94 |     1
+  98 | 100 |     1
+  95 |  97 |     1
+  91 |  93 |     1
+  91 |  95 |     0
+ 100 | 102 |     1
+  96 |  98 |     1
+(11 rows)
+
+-- GROUPING SETS
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by grouping sets((c1), (c3));
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ HashAggregate
+   Output: c1, c3, count(c2)
+   Hash Key: aqumv_t3.c1
+   Hash Key: aqumv_t3.c3
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: c1, c3, c2
+         ->  Seq Scan on public.aqumv_t3
+               Output: c1, c3, c2
+               Filter: (aqumv_t3.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by grouping sets((c1), (c3));
+ c1  | c3  | count 
+-----+-----+-------
+  92 |     |     1
+  93 |     |     1
+  99 |     |     1
+  94 |     |     1
+ 100 |     |     1
+  97 |     |     1
+  96 |     |     1
+  98 |     |     1
+  95 |     |     1
+  91 |     |     1
+     | 101 |     1
+     |  93 |     1
+     |  99 |     1
+     |  94 |     1
+     | 100 |     1
+     | 102 |     1
+     |  96 |     1
+     |  97 |     1
+     |  98 |     1
+     |  95 |     1
+(20 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by grouping sets((c1), (c3));
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ HashAggregate
+   Output: mc1, mc3, count(mc2)
+   Hash Key: aqumv_mvt3_0.mc1
+   Hash Key: aqumv_mvt3_0.mc3
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: mc1, mc3, mc2
+         ->  Seq Scan on public.aqumv_mvt3_0
+               Output: mc1, mc3, mc2
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by grouping sets((c1), (c3));
+ c1  | c3  | count 
+-----+-----+-------
+  92 |     |     1
+  93 |     |     1
+  99 |     |     1
+  94 |     |     1
+ 100 |     |     1
+  96 |     |     1
+  97 |     |     1
+  98 |     |     1
+  95 |     |     1
+  91 |     |     1
+     |  93 |     1
+     | 101 |     1
+     |  99 |     1
+     |  94 |     1
+     | 100 |     1
+     | 102 |     1
+     |  97 |     1
+     |  96 |     1
+     |  98 |     1
+     |  95 |     1
+(20 rows)
+
+-- ROLLUP
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by rollup(c1, c3);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ GroupAggregate
+   Output: c1, c3, count(c2)
+   Group Key: aqumv_t3.c1, aqumv_t3.c3
+   Group Key: aqumv_t3.c1
+   Group Key: ()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: c1, c3, c2
+         Merge Key: c1, c3
+         ->  Sort
+               Output: c1, c3, c2
+               Sort Key: aqumv_t3.c1, aqumv_t3.c3
+               ->  Seq Scan on public.aqumv_t3
+                     Output: c1, c3, c2
+                     Filter: (aqumv_t3.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by rollup(c1, c3);
+ c1  | c3  | count 
+-----+-----+-------
+  91 |  93 |     1
+  91 |  95 |     0
+  91 |     |     1
+  92 |  94 |     1
+  92 |     |     1
+  93 |  95 |     1
+  93 |     |     1
+  94 |  96 |     1
+  94 |     |     1
+  95 |  97 |     1
+  95 |     |     1
+  96 |  98 |     1
+  96 |     |     1
+  97 |  99 |     1
+  97 |     |     1
+  98 | 100 |     1
+  98 |     |     1
+  99 | 101 |     1
+  99 |     |     1
+ 100 | 102 |     1
+ 100 |     |     1
+     |     |    10
+(22 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by rollup(c1, c3);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ GroupAggregate
+   Output: mc1, mc3, count(mc2)
+   Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
+   Group Key: aqumv_mvt3_0.mc1
+   Group Key: ()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: mc1, mc3, mc2
+         Merge Key: mc1, mc3
+         ->  Sort
+               Output: mc1, mc3, mc2
+               Sort Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
+               ->  Seq Scan on public.aqumv_mvt3_0
+                     Output: mc1, mc3, mc2
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by rollup(c1, c3);
+ c1  | c3  | count 
+-----+-----+-------
+  91 |  93 |     1
+  91 |  95 |     0
+  91 |     |     1
+  92 |  94 |     1
+  92 |     |     1
+  93 |  95 |     1
+  93 |     |     1
+  94 |  96 |     1
+  94 |     |     1
+  95 |  97 |     1
+  95 |     |     1
+  96 |  98 |     1
+  96 |     |     1
+  97 |  99 |     1
+  97 |     |     1
+  98 | 100 |     1
+  98 |     |     1
+  99 | 101 |     1
+  99 |     |     1
+ 100 | 102 |     1
+ 100 |     |     1
+     |     |    10
+(22 rows)
+
+-- CUBE
+set local enable_answer_query_using_materialized_views = off;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ MixedAggregate
+   Output: c1, c3, count(c2)
+   Hash Key: aqumv_t3.c3
+   Group Key: aqumv_t3.c1, aqumv_t3.c3
+   Group Key: aqumv_t3.c1
+   Group Key: ()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: c1, c3, c2
+         Merge Key: c1, c3
+         ->  Sort
+               Output: c1, c3, c2
+               Sort Key: aqumv_t3.c1, aqumv_t3.c3
+               ->  Seq Scan on public.aqumv_t3
+                     Output: c1, c3, c2
+                     Filter: (aqumv_t3.c1 > 90)
+ Settings: enable_answer_query_using_materialized_views = 'off', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
+ c1  | c3  | count 
+-----+-----+-------
+  91 |  93 |     1
+  91 |  95 |     0
+  91 |     |     1
+  92 |  94 |     1
+  92 |     |     1
+  93 |  95 |     1
+  93 |     |     1
+  94 |  96 |     1
+  94 |     |     1
+  95 |  97 |     1
+  95 |     |     1
+  96 |  98 |     1
+  96 |     |     1
+  97 |  99 |     1
+  97 |     |     1
+  98 | 100 |     1
+  98 |     |     1
+  99 | 101 |     1
+  99 |     |     1
+ 100 | 102 |     1
+ 100 |     |     1
+     |     |    10
+     | 101 |     1
+     |  93 |     1
+     |  99 |     1
+     |  94 |     1
+     | 100 |     1
+     | 102 |     1
+     |  97 |     1
+     |  96 |     1
+     |  98 |     1
+     |  95 |     1
+(32 rows)
+
+set local enable_answer_query_using_materialized_views = on;
+explain(costs off, verbose)
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ MixedAggregate
+   Output: mc1, mc3, count(mc2)
+   Hash Key: aqumv_mvt3_0.mc3
+   Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
+   Group Key: aqumv_mvt3_0.mc1
+   Group Key: ()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: mc1, mc3, mc2
+         Merge Key: mc1, mc3
+         ->  Sort
+               Output: mc1, mc3, mc2
+               Sort Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
+               ->  Seq Scan on public.aqumv_mvt3_0
+                     Output: mc1, mc3, mc2
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
+ c1  | c3  | count 
+-----+-----+-------
+  91 |  93 |     1
+  91 |  95 |     0
+  91 |     |     1
+  92 |  94 |     1
+  92 |     |     1
+  93 |  95 |     1
+  93 |     |     1
+  94 |  96 |     1
+  94 |     |     1
+  95 |  97 |     1
+  95 |     |     1
+  96 |  98 |     1
+  96 |     |     1
+  97 |  99 |     1
+  97 |     |     1
+  98 | 100 |     1
+  98 |     |     1
+  99 | 101 |     1
+  99 |     |     1
+ 100 | 102 |     1
+ 100 |     |     1
+     |     |    10
+     | 101 |     1
+     |  93 |     1
+     |  99 |     1
+     |  94 |     1
+     | 100 |     1
+     | 102 |     1
+     |  97 |     1
+     |  96 |     1
+     |  98 |     1
+     |  95 |     1
+(32 rows)
+
+abort;
 reset optimizer;
 reset enable_answer_query_using_materialized_views;
 drop table aqumv_t1 cascade;


### PR DESCRIPTION
Support Clauses like: **Group By column(s), GROUPING SETS, ROLLUP, CUBE** in origin query if they could be computed from materialized views's target list.
```sql
create incremental materialized view mv as
  select c1 as mc1, c2 as mc2, c3 as mc3
  from t1 where c1 > 90;
```
Origin query:
```sql
  select c1, c3, count(c2) from t1 where c1 > 90
  group by c1, c3;
```
Could be rewritten to:
```sql
  select mc1, mc3, count(mc2) from mv
  group by mc1, mc3;
```


## example DDL
```sql
create table aqumv_t3(c1 int, c2 int, c3 int) distributed by (c1);
insert into aqumv_t3 select i, i+1, i+2 from generate_series(1, 100) i;
insert into aqumv_t3 values (91, NULL, 95);
analyze aqumv_t3;
create incremental materialized view aqumv_mvt3_0 as
  select c1 as mc1, c2 as mc2, c3 as mc3
  from aqumv_t3 where c1 > 90;
analyze aqumv_mvt3_0;
```
### Group BY(columns)
```sql
explain(costs off, verbose)
select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by c1, c3;
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: mc1, mc3, (count(mc2))
   ->  HashAggregate
         Output: mc1, mc3, count(mc2)
         Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
         ->  Seq Scan on public.aqumv_mvt3_0
               Output: mc1, mc2, mc3
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(9 rows)
```
### Grouping Sets
```sql
explain(costs off, verbose)
select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by grouping sets((c1), (c3));
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 HashAggregate
   Output: mc1, mc3, count(mc2)
   Hash Key: aqumv_mvt3_0.mc1
   Hash Key: aqumv_mvt3_0.mc3
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: mc1, mc3, mc2
         ->  Seq Scan on public.aqumv_mvt3_0
               Output: mc1, mc3, mc2
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(10 rows)
```
### ROLLUP
```sql
explain(costs off, verbose)
select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by rollup(c1, c3);
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 GroupAggregate
   Output: mc1, mc3, count(mc2)
   Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
   Group Key: aqumv_mvt3_0.mc1
   Group Key: ()
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: mc1, mc3, mc2
         Merge Key: mc1, mc3
         ->  Sort
               Output: mc1, mc3, mc2
               Sort Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
               ->  Seq Scan on public.aqumv_mvt3_0
                     Output: mc1, mc3, mc2
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(15 rows)
```
### CUBE
```sql
explain(costs off, verbose)
select c1, c3, count(c2) from aqumv_t3 where c1 > 90 group by cube(c1, c3);
                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 MixedAggregate
   Output: mc1, mc3, count(mc2)
   Hash Key: aqumv_mvt3_0.mc3
   Group Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
   Group Key: aqumv_mvt3_0.mc1
   Group Key: ()
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: mc1, mc3, mc2
         Merge Key: mc1, mc3
         ->  Sort
               Output: mc1, mc3, mc2
               Sort Key: aqumv_mvt3_0.mc1, aqumv_mvt3_0.mc3
               ->  Seq Scan on public.aqumv_mvt3_0
                     Output: mc1, mc3, mc2
 Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
 Optimizer: Postgres query optimizer
(16 rows)
```










Authored-by: Zhang Mingli avamingli@gmail.com

<!--Thank you for contributing!-->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

### Change logs

_Describe your change clearly, including what problem is being solved or what feature is being added._

_If it has some breaking backward or forward compatibility, please clary._

### Why are the changes needed?

_Describe why the changes are necessary._

### Does this PR introduce any user-facing change?

_If yes, please clarify the previous behavior and the change this PR proposes._

### How was this patch tested?

_Please detail how the changes were tested, including manual tests and any relevant unit or integration tests._

### Contributor's Checklist

Here are some reminders and checklists before/when submitting your pull request, please check them:

- [ ] Make sure your Pull Request has a clear title and commit message. You can take [git-commit](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) template as a reference.
- [ ] Sign the Contributor License Agreement as prompted for your first-time contribution(*One-time setup*).
- [ ] Learn the [coding contribution guide](https://cloudberrydb.org/contribute/code), including our code conventions, workflow and more.
- [ ] List your communication in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
- [ ] Document changes.
- [ ] Add tests for the change
- [ ] Pass `make installcheck`
- [ ] Pass `make -C src/test installcheck-cbdb-parallel`
- [ ] Feel free to request `cloudberrydb/dev` team for review and approval when your PR is ready🥳
