### PR TITLE
Rephrase comment for deferred IVM case

### DIFF
--- a/src/backend/optimizer/plan/aqumv.c
+++ b/src/backend/optimizer/plan/aqumv.c
@@ -171,7 +171,8 @@ answer_query_using_materialized_views(PlannerInfo *root,
 		/*
 		 * AQUMV
 		 * Currently the data of IVM is always up-to-date if there were.
-		 * Take care of this when IVM defered-fefresh is supported.
+                 * However, we place this future-proof condition to take
+		 * care of IVM deferred maintenance/incremental refresh feature.
 		 */
 		if (!(RelationIsIVM(matviewRel) && RelationIsPopulated(matviewRel)))
 			continue;


### PR DESCRIPTION
Have been studying AQUMV feature internals today.  Noticed the typo in comment, and decided to rephrase it a little bit. This way it is more clear IMO.
